### PR TITLE
Add support for ordering object files during merge

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,9 +31,10 @@ FLAGS:
     -v, --verbose    Print verbose information
 
 OPTIONS:
-    -k, --keep-symbols <keep-symbols>...     Accepts regexes of the symbol names to keep global, and localizes the rest
-    -r, --remove-symbols <remove-symbols>... Accepts regexes of the symbol names to hide, and keep the rest global
-    -o, --output <output>                    Output static library
+    -k, --keep-symbols <keep-symbols>...        Accepts regexes of the symbol names to keep global, and localizes the rest
+        --order-file <order-file>               Order file to control the sorting of merged objects
+    -o, --output <output>                       Output static library
+    -r, --remove-symbols <remove-symbols>...    Accepts regexes of the symbol names to hide, and keep the rest global
 
 ARGS:
     <INPUTS>...    Static libraries to merge
@@ -53,6 +54,24 @@ You may specify a different objcopy implementation with the `OBJCOPY` env var, a
 
 You can use armerge to handle Linux/Android archives on a macOS host if the right toolchain is installed.
 (i.e. you may need to set `LD`, `OBJCOPY`, and `RANLIB` to point to the Android NDK, or to some other toolchain).
+
+## Object merge order
+
+By default, objects are passed to the linker in an unspecified order. Linkers typically lay out the output file's sections in the order the inputs are specified.
+
+If you want to control the order in which some of the object files are merged, you can use the `--order-file` option. With this option, you can specify an order file that controls the relative order in which armerge passes the listed object files to the linker, so you can precisely control the order in which certain sections will be laid out in the output.
+
+The order file is a plain text file with one entry per line, in the format `{INPUT_LIB}@{OBJNAME}`, where `INPUT_LIB` is the name of the input library and `OBJNAME` is the name of the object file to select from that library. Blank lines or lines starting with the `#` sign are ignored. Any object files not listed are placed after all of the listed objects in an unspecified order. For example:
+
+```
+# Place the custom malloc object file first
+libmyallocator.a@mymalloc.o
+
+# Place the app's entry point next
+libmyapp.a@entry.o
+
+# All other object files are placed after this in an unspecified order.
+```
 
 ## Principle of operation
 

--- a/src/archives.rs
+++ b/src/archives.rs
@@ -148,6 +148,12 @@ pub fn extract_objects<I: IntoParallelIterator<Item = InputLibrary<R>>, R: Read>
     })
 }
 
+pub fn get_object_name_from_path(path: &std::path::Path) -> String {
+    let filename = path.file_name().unwrap().to_string_lossy();
+    let name_parts = filename.rsplitn(3, '.').collect::<Vec<_>>();
+    name_parts[2].to_string()
+}
+
 pub fn create_index(archive_path: &std::path::Path) -> Result<(), MergeError> {
     use std::process::Command;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -104,12 +104,25 @@ impl ArMerger {
         keep_or_remove: ArmergeKeepOrRemove,
         symbols_regexes: Iter,
     ) -> Result<(), MergeError> {
+        self.merge_and_localize_ordered(keep_or_remove, symbols_regexes, std::iter::empty())
+    }
+
+    /// Merge input libraries in a specified order and localize non-public symbols
+    /// `keep_symbols_regexes` contains the regex name pattern for public symbols to keep exported
+    /// `object_order` contains the order in which certain object files will be merged
+    pub fn merge_and_localize_ordered<Iter: IntoIterator<Item = Regex>>(
+        self,
+        keep_or_remove: ArmergeKeepOrRemove,
+        symbols_regexes: Iter,
+        object_order: impl IntoIterator<Item = String>
+    ) -> Result<(), MergeError> {
         objects::merge(
             self.builder,
             self.extracted.contents_type,
             self.extracted.object_dir,
             keep_or_remove,
             symbols_regexes.into_iter().collect(),
+            object_order.into_iter().enumerate().map(|(i, s)| (s, i)).collect()
         )
     }
 }

--- a/src/objects/builtin_filter.rs
+++ b/src/objects/builtin_filter.rs
@@ -9,7 +9,7 @@ use crate::objects::syms::ObjectSyms;
 pub fn merge_required_objects(
     _obj_dir: &Path,
     merged_path: &Path,
-    objects: &HashMap<PathBuf, ObjectSyms>,
+    objects: &[PathBuf],
     keep_or_remove: ArmergeKeepOrRemove,
     regexes: &[Regex],
 ) -> Result<(), MergeError> {
@@ -18,7 +18,7 @@ pub fn merge_required_objects(
     }
 
     // The merging part is still not builtin, it has to be done by a real linker
-    merge::create_merged_object(merged_path, &[], objects.keys(), false)?;
+    merge::create_merged_object(merged_path, &[], objects, false)?;
 
     // Filtering the symbols is faster in pure Rust, compared to calling the system's objcopy
     let merged_elf = std::fs::read(merged_path)?;

--- a/src/objects/builtin_filter.rs
+++ b/src/objects/builtin_filter.rs
@@ -1,10 +1,8 @@
 use crate::{ArmergeKeepOrRemove, MergeError};
 use regex::Regex;
-use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
 use crate::objects::merge;
-use crate::objects::syms::ObjectSyms;
 
 pub fn merge_required_objects(
     _obj_dir: &Path,

--- a/src/objects/filter_deps.rs
+++ b/src/objects/filter_deps.rs
@@ -6,6 +6,7 @@ use rayon::prelude::*;
 use regex::Regex;
 use tracing::{event_enabled, info, Level};
 
+use crate::archives::get_object_name_from_path;
 use crate::objects::syms::ObjectSyms;
 
 fn add_deps_recursive(
@@ -40,11 +41,9 @@ pub fn filter_required_objects(
     for (obj_path, obj) in object_syms.iter() {
         if obj.has_exported_symbols {
             if event_enabled!(Level::INFO) {
-                let filename = obj_path.file_name().unwrap().to_string_lossy();
-                let name_parts = filename.rsplitn(3, '.').collect::<Vec<_>>();
                 info!(
                     "Will merge {:?} and its dependencies, as it contains global kept symbols",
-                    name_parts[2],
+                    get_object_name_from_path(obj_path),
                 );
             }
             required_objs.insert(obj_path.clone());
@@ -55,11 +54,9 @@ pub fn filter_required_objects(
     if event_enabled!(Level::INFO) {
         for obj in object_syms.keys() {
             if !required_objs.contains(obj) {
-                let filename = obj.file_name().unwrap().to_string_lossy();
-                let name_parts = filename.rsplitn(3, '.').collect::<Vec<_>>();
                 info!(
                     "`{}` is not used by any kept objects, it will be skipped",
-                    name_parts[2]
+                    get_object_name_from_path(obj)
                 )
             }
         }

--- a/src/objects/system_filter.rs
+++ b/src/objects/system_filter.rs
@@ -1,5 +1,5 @@
 use goblin::{peek_bytes, Hint};
-use std::collections::{HashMap, HashSet};
+use std::collections::HashSet;
 use std::ffi::OsString;
 use std::io::{Read, Seek, SeekFrom, Write};
 use std::path::{Path, PathBuf};
@@ -7,7 +7,6 @@ use std::process::Command;
 use std::str::FromStr;
 
 use crate::objects::merge::create_merged_object;
-use crate::objects::syms::ObjectSyms;
 use crate::{ArmergeKeepOrRemove, MergeError};
 use object::{Object, ObjectSymbol, SymbolKind};
 use regex::Regex;
@@ -144,23 +143,23 @@ fn filter_symbols(object_path: &Path, filter_list_path: &Path) -> Result<(), Mer
 pub fn merge_required_macho_objects(
     obj_dir: &Path,
     merged_path: &Path,
-    objects: &HashMap<PathBuf, ObjectSyms>,
+    objects: &[PathBuf],
     keep_or_remove: ArmergeKeepOrRemove,
     regexes: &[Regex],
 ) -> Result<(), MergeError> {
-    let filter_path = create_symbol_filter_list(obj_dir, objects.keys(), keep_or_remove, regexes)?;
-    create_filtered_merged_macho_object(merged_path, objects.keys(), &filter_path)
+    let filter_path = create_symbol_filter_list(obj_dir, objects, keep_or_remove, regexes)?;
+    create_filtered_merged_macho_object(merged_path, objects, &filter_path)
 }
 
 pub fn merge_required_objects(
     obj_dir: &Path,
     merged_path: &Path,
-    objects: &HashMap<PathBuf, ObjectSyms>,
+    objects: &[PathBuf],
     keep_or_remove: ArmergeKeepOrRemove,
     regexes: &[Regex],
 ) -> Result<(), MergeError> {
-    let filter_path = create_symbol_filter_list(obj_dir, objects.keys(), keep_or_remove, regexes)?;
-    create_filtered_merged_object(merged_path, objects.keys(), &filter_path)?;
+    let filter_path = create_symbol_filter_list(obj_dir, objects, keep_or_remove, regexes)?;
+    create_filtered_merged_object(merged_path, objects, &filter_path)?;
 
     // If a symbol we localize is in a COMDAT section group, we also want to turn it into a regular
     // section group. Otherwise the local symbol is not really local, because the containing section


### PR DESCRIPTION
This PR adds a new `--order-file` option that allows you to control the order in which some of the object files are passed to the linker, and thus the order in which certain sections and items are laid out in the merged library.

The motivating use case here is controlling the order in which static initializers are run on startup on macOS and iOS. Static initializers are listed in the [`S_MOD_INIT_FUNC_POINTERS`](https://docs.rs/mach_object/latest/mach_object/constant.S_MOD_INIT_FUNC_POINTERS.html) Mach-O section, and the order in which they appear there is the order in which [dyld calls them at runtime](https://github.com/apple-oss-distributions/dyld/blob/66c652a1/common/MachOAnalyzer.cpp#L2417).

Unfortunately, the Apple linker does not honor the [priority value in constructor and destructor attributes](https://gcc.gnu.org/onlinedocs/gcc/Common-Function-Attributes.html#index-constructor-function-attribute) across object files, so even if you mark an initializer with `__attribute__((constructor(101))` it might end up being called _after_ an initializer in another object file marked with `__attribute__((constructor(102))`. And the `-order_file` linker option does not affect the order in which the initializers are listed in the `__mod_init_func` section. The order is always based on **the order in which the object files are passed to the linker**.

With this new option, you can now specify an order file that controls the relative order in which `armerge` passes the listed object files to the linker, so you can precisely control the order in which static initializers will be called at runtime. The order file is a simple text file with an entry per line, in the format `{INPUT_LIB}@{OBJNAME}`. Any object files not listed are placed after all of the listed objects in an unspecified order, like before. For example:

```
# Place the custom malloc object file first
libmyallocator.a@mymalloc.o

# Place the app entry point next
libmyapp.a@entry.o
```