### PR TITLE
Merge objects in alphabetical order for determinism

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,11 +57,11 @@ You can use armerge to handle Linux/Android archives on a macOS host if the righ
 
 ## Object merge order
 
-By default, objects are passed to the linker in an unspecified order. Linkers typically lay out the output file's sections in the order the inputs are specified.
+By default, objects are passed to the linker in alphabetical order. Linkers typically lay out the output file's sections in the order the inputs are specified. Passing the objects in alphabetical order helps make the output deterministic.
 
 If you want to control the order in which some of the object files are merged, you can use the `--order-file` option. With this option, you can specify an order file that controls the relative order in which armerge passes the listed object files to the linker, so you can precisely control the order in which certain sections will be laid out in the output.
 
-The order file is a plain text file with one entry per line, in the format `{INPUT_LIB}@{OBJNAME}`, where `INPUT_LIB` is the name of the input library and `OBJNAME` is the name of the object file to select from that library. Blank lines or lines starting with the `#` sign are ignored. Any object files not listed are placed after all of the listed objects in an unspecified order. For example:
+The order file is a plain text file with one entry per line, in the format `{INPUT_LIB}@{OBJNAME}`, where `INPUT_LIB` is the name of the input library and `OBJNAME` is the name of the object file to select from that library. Blank lines or lines starting with the `#` sign are ignored. Any object files not listed are placed after all of the listed objects, in alphabetical order. For example:
 
 ```
 # Place the custom malloc object file first
@@ -70,7 +70,7 @@ libmyallocator.a@mymalloc.o
 # Place the app's entry point next
 libmyapp.a@entry.o
 
-# All other object files are placed after this in an unspecified order.
+# All other object files are placed after this in alphabetical order.
 ```
 
 ## Principle of operation

--- a/src/objects/filter_deps.rs
+++ b/src/objects/filter_deps.rs
@@ -1,4 +1,4 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, HashSet};
 use std::path::PathBuf;
 
 use crate::{ArmergeKeepOrRemove, MergeError};
@@ -11,7 +11,7 @@ use crate::objects::syms::ObjectSyms;
 
 fn add_deps_recursive(
     objs_set: &mut HashSet<PathBuf>,
-    syms: &HashMap<PathBuf, ObjectSyms>,
+    syms: &BTreeMap<PathBuf, ObjectSyms>,
     obj: &ObjectSyms,
 ) {
     for dep in &obj.deps {
@@ -25,7 +25,7 @@ pub fn filter_required_objects(
     objects: &[PathBuf],
     keep_or_remove: ArmergeKeepOrRemove,
     regexes: &[Regex],
-) -> Result<HashMap<PathBuf, ObjectSyms>, MergeError> {
+) -> Result<BTreeMap<PathBuf, ObjectSyms>, MergeError> {
     let mut object_syms = objects
         .into_par_iter()
         .map(|obj_path| {
@@ -34,7 +34,7 @@ pub fn filter_required_objects(
                 ObjectSyms::new(obj_path, keep_or_remove, regexes)?,
             ))
         })
-        .collect::<Result<HashMap<PathBuf, ObjectSyms>, _>>()?;
+        .collect::<Result<BTreeMap<PathBuf, ObjectSyms>, _>>()?;
     ObjectSyms::check_dependencies(&mut object_syms);
 
     let mut required_objs = HashSet::new();

--- a/src/objects/syms.rs
+++ b/src/objects/syms.rs
@@ -2,7 +2,7 @@ use crate::{ArmergeKeepOrRemove, MergeError};
 use object::{Object, ObjectSymbol, SymbolKind};
 use rayon::prelude::*;
 use regex::Regex;
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, HashSet};
 use std::path::{Path, PathBuf};
 
 pub struct ObjectSyms {
@@ -79,7 +79,7 @@ impl ObjectSyms {
         false
     }
 
-    pub fn check_dependencies(object_syms: &mut HashMap<PathBuf, Self>) {
+    pub fn check_dependencies(object_syms: &mut BTreeMap<PathBuf, Self>) {
         let deps_map = object_syms
             .par_iter()
             .map(|(left_path, left_syms)| {
@@ -95,7 +95,7 @@ impl ObjectSyms {
                 }
                 (left_path.to_owned(), deps)
             })
-            .collect::<HashMap<_, _>>();
+            .collect::<BTreeMap<_, _>>();
         for (path, deps) in deps_map {
             object_syms.get_mut(&path).unwrap().deps = deps;
         }


### PR DESCRIPTION
As discussed in #9, making armerge's output deterministic is generally valuable. The main thing breaking determinism was the random merge order of objects due to the use of `HashMap`, which [intentionally randomizes the order of entries](https://doc.rust-lang.org/std/collections/hash_map/struct.HashMap.html). Using `BTreeMap` instead to always merge objects in alphabetical order helps maintain determinism.

There are still some sources of nondeterminism, but those are easier to manage by the user of the tool. For example, if an input library contains several objects with the same name, then the merge order of those objects is still nondeterministic because of the [random suffix](https://github.com/tux3/armerge/blob/180564c/src/archives.rs#L94) added to object names. The user could ensure there are no identically named objects in a given input library prior to calling armerge.