### PR TITLE
Separate library from CLI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,15 +27,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ansi_term"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
-dependencies = [
- "winapi",
-]
-
-[[package]]
 name = "anstream"
 version = "0.6.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -87,9 +78,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.95"
+version = "1.0.96"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34ac096ce696dc2fcabef30516bb13c0a68a11d30131d3df6f04711467681b04"
+checksum = "6b964d184e89d9b6b67dd2715bc8e74cf3107fb2b529990c90cf517326150bf4"
 dependencies = [
  "backtrace",
 ]
@@ -105,8 +96,7 @@ name = "armerge"
 version = "2.2.0"
 dependencies = [
  "ar",
- "clap 4.5.30",
- "goblin 0.9.3",
+ "goblin",
  "object",
  "objpoke",
  "rand",
@@ -114,20 +104,19 @@ dependencies = [
  "regex",
  "tempfile",
  "thiserror",
- "time",
  "tracing",
- "tracing-subscriber",
 ]
 
 [[package]]
-name = "atty"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
+name = "armerge-cli"
+version = "2.2.0"
 dependencies = [
- "hermit-abi",
- "libc",
- "winapi",
+ "armerge",
+ "clap",
+ "regex",
+ "time",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -144,12 +133,6 @@ dependencies = [
  "rustc-demangle",
  "windows-targets",
 ]
-
-[[package]]
-name = "bitflags"
-version = "1.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
@@ -171,24 +154,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "2.34.0"
+version = "4.5.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
-dependencies = [
- "ansi_term",
- "atty",
- "bitflags 1.3.2",
- "strsim 0.8.0",
- "textwrap",
- "unicode-width",
- "vec_map",
-]
-
-[[package]]
-name = "clap"
-version = "4.5.30"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92b7b18d71fad5313a1e320fa9897994228ce274b60faa4d694fe0ea89cd9e6d"
+checksum = "027bb0d98429ae334a8698531da7077bdf906419543a35a55c2cb1b66437d767"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -196,14 +164,14 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.30"
+version = "4.5.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a35db2071778a7344791a4fb4f95308b5673d219dee3ae348b86642574ecc90c"
+checksum = "5589e0cba072e0f3d23791efac0fd8627b49c829c196a492e88168e6a669d863"
 dependencies = [
  "anstream",
  "anstyle",
  "clap_lex",
- "strsim 0.11.1",
+ "strsim",
 ]
 
 [[package]]
@@ -212,10 +180,10 @@ version = "4.5.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf4ced95c6f4a675af3da73304b9ac4ed991640c36374e4b46795c49e17cf1ed"
 dependencies = [
- "heck 0.5.0",
+ "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn",
 ]
 
 [[package]]
@@ -275,9 +243,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.13.0"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
+checksum = "b7914353092ddf589ad78f25c5c1c21b7f80b0ff8621e7c814c3485b5306da9d"
 
 [[package]]
 name = "errno"
@@ -297,23 +265,12 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "flate2"
-version = "1.0.35"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c936bfdafb507ebbf50b8074c54fa31c5be9a1e7e5f467dd659697041407d07c"
+checksum = "11faaf5a5236997af9848be0bef4db95824b1d534ebc64d0f0c6cf3e67bd38dc"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
-]
-
-[[package]]
-name = "getrandom"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
-dependencies = [
- "cfg-if",
- "libc",
- "wasi 0.11.0+wasi-snapshot-preview1",
 ]
 
 [[package]]
@@ -324,7 +281,7 @@ checksum = "43a49c392881ce6d5c3b8cb70f98717b7c07aabbdff06687b9030dbfbe2725f8"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi 0.13.3+wasi-0.2.2",
+ "wasi",
  "windows-targets",
 ]
 
@@ -336,33 +293,13 @@ checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
 name = "goblin"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee05c709047abe5eb0571880d2887ac77299c5f0835f8e6b7f4d5404f8962921"
-dependencies = [
- "log",
- "plain",
- "scroll 0.10.2",
-]
-
-[[package]]
-name = "goblin"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "daa0a64d21a7eb230583b4c5f4e23b7e4e57974f96620f42a7e75e08ae66d745"
 dependencies = [
  "log",
  "plain",
- "scroll 0.12.0",
-]
-
-[[package]]
-name = "heck"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
-dependencies = [
- "unicode-segmentation",
+ "scroll",
 ]
 
 [[package]]
@@ -372,15 +309,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
-name = "hermit-abi"
-version = "0.1.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -388,9 +316,9 @@ checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
 name = "itoa"
-version = "1.0.14"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
+checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "lazy_static"
@@ -400,21 +328,21 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.169"
+version = "0.2.170"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
+checksum = "875b3680cb2f8f71bdcf9a30f38d48282f5d3c95cbf9b3fa57269bb5d5c06828"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.15"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+checksum = "6db9c683daf087dc577b7506e9695b3d556a9f3849903fa28186283afd6809e9"
 
 [[package]]
 name = "log"
-version = "0.4.25"
+version = "0.4.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04cbf5b083de1c7e0222a7a51dbfdba1cbe1c6ab0b15e29fff3f6c077fd9cd9f"
+checksum = "30bde2b3dc3671ae49d8e2e9f044c7c005836e7a023ee57cffa25ab82764bb9e"
 
 [[package]]
 name = "matchers"
@@ -433,9 +361,9 @@ checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.8.3"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8402cab7aefae129c6977bb0ff1b8fd9a04eb5b51efc50a70bea51cda0c7924"
+checksum = "8e3e04debbb59698c15bacbb6d93584a8c0ca9cc3213cb423d31f760d8843ce5"
 dependencies = [
  "adler2",
 ]
@@ -457,15 +385,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
 
 [[package]]
-name = "num_threads"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "object"
 version = "0.36.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -479,21 +398,19 @@ dependencies = [
 [[package]]
 name = "objpoke"
 version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f226d2911ce4e28bc72827065e0e2a1fe4f4c8eda83ec919cd724720a5500c30"
+source = "git+https://github.com/dice-group/objpoke?rev=c43ab668dafcb4bfbd7c16a0dd654ee759d7fbb3#c43ab668dafcb4bfbd7c16a0dd654ee759d7fbb3"
 dependencies = [
  "anyhow",
- "goblin 0.4.1",
+ "goblin",
  "regex",
- "scroll 0.10.2",
- "structopt",
+ "scroll",
 ]
 
 [[package]]
 name = "once_cell"
-version = "1.20.2"
+version = "1.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
+checksum = "945462a4b81e43c4e3ba96bd7b49d834c6f61198356aa858733bc4acf3cbe62e"
 
 [[package]]
 name = "overload"
@@ -525,31 +442,7 @@ version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
 dependencies = [
- "zerocopy",
-]
-
-[[package]]
-name = "proc-macro-error"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
-dependencies = [
- "proc-macro-error-attr",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
- "version_check",
-]
-
-[[package]]
-name = "proc-macro-error-attr"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
-dependencies = [
- "proc-macro2",
- "quote",
- "version_check",
+ "zerocopy 0.7.35",
 ]
 
 [[package]]
@@ -572,20 +465,20 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "3779b94aeb87e8bd4e834cee3650289ee9e0d5677f976ecdb6d219e5f4f6cd94"
 dependencies = [
- "libc",
  "rand_chacha",
  "rand_core",
+ "zerocopy 0.8.20",
 ]
 
 [[package]]
 name = "rand_chacha"
-version = "0.3.1"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
  "rand_core",
@@ -593,11 +486,12 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.6.4"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+checksum = "7a509b1a2ffbe92afab0e55c8fd99dea1c280e8171bd2d88682bb20bc41cbc2c"
 dependencies = [
- "getrandom 0.2.15",
+ "getrandom",
+ "zerocopy 0.8.20",
 ]
 
 [[package]]
@@ -672,11 +566,11 @@ checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
 
 [[package]]
 name = "rustix"
-version = "0.38.44"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+checksum = "f7178faa4b75a30e269c71e61c353ce2748cf3d76f0c44c393f4e60abf49b825"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -694,31 +588,11 @@ dependencies = [
 
 [[package]]
 name = "scroll"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fda28d4b4830b807a8b43f7b0e6b5df875311b3e7621d84577188c175b6ec1ec"
-dependencies = [
- "scroll_derive 0.10.5",
-]
-
-[[package]]
-name = "scroll"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ab8598aa408498679922eff7fa985c25d58a90771bd6be794434c5277eab1a6"
 dependencies = [
- "scroll_derive 0.12.0",
-]
-
-[[package]]
-name = "scroll_derive"
-version = "0.10.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aaaae8f38bb311444cfb7f1979af0bc9240d95795f75f9ceddf6a59b79ceffa0"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
+ "scroll_derive",
 ]
 
 [[package]]
@@ -729,27 +603,27 @@ checksum = "7f81c2fde025af7e69b1d1420531c8a8811ca898919db177141a85313b1cb932"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn",
 ]
 
 [[package]]
 name = "serde"
-version = "1.0.217"
+version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02fc4265df13d6fa1d00ecff087228cc0a2b5f3c0e87e258d8b94a156e984c70"
+checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.217"
+version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a9bf7cf98d04a2b28aead066b7496853d4779c9cc183c440dbac457641e19a0"
+checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn",
 ]
 
 [[package]]
@@ -763,9 +637,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.13.2"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
+checksum = "7fcf8323ef1faaee30a44a340193b1ac6814fd9b7b4e88e9d4519a3e4abe1cfd"
 
 [[package]]
 name = "static_assertions"
@@ -775,50 +649,9 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "strsim"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
-
-[[package]]
-name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
-
-[[package]]
-name = "structopt"
-version = "0.3.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c6b5c64445ba8094a6ab0c3cd2ad323e07171012d9c98b0b15651daf1787a10"
-dependencies = [
- "clap 2.34.0",
- "lazy_static",
- "structopt-derive",
-]
-
-[[package]]
-name = "structopt-derive"
-version = "0.4.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcb5ae327f9cc13b68763b5749770cb9e048a99bd9dfdfa58d0cf05d5f64afe0"
-dependencies = [
- "heck 0.3.3",
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "syn"
-version = "1.0.109"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-ident",
-]
 
 [[package]]
 name = "syn"
@@ -833,45 +666,36 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.16.0"
+version = "3.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38c246215d7d24f48ae091a2902398798e05d978b24315d6efbc00ede9a8bb91"
+checksum = "2c317e0a526ee6120d8dabad239c8dadca62b24b6f168914bbbc8e2fb1f0e567"
 dependencies = [
  "cfg-if",
  "fastrand",
- "getrandom 0.3.1",
+ "getrandom",
  "once_cell",
  "rustix",
  "windows-sys",
 ]
 
 [[package]]
-name = "textwrap"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
-dependencies = [
- "unicode-width",
-]
-
-[[package]]
 name = "thiserror"
-version = "2.0.11"
+version = "2.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d452f284b73e6d76dd36758a0c8684b1d5be31f92b89d07fd5822175732206fc"
+checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.11"
+version = "2.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26afc1baea8a989337eeb52b6e72a039780ce45c3edfcc9c5b9d112feeb173c2"
+checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn",
 ]
 
 [[package]]
@@ -886,15 +710,13 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.37"
+version = "0.3.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35e7868883861bd0e56d9ac6efcaaca0d6d5d82a2a7ec8209ff492c07cf37b21"
+checksum = "dad298b01a40a23aac4580b67e3dbedb7cc8402f3592d7f49469de2ea4aecdd8"
 dependencies = [
  "deranged",
  "itoa",
- "libc",
  "num-conv",
- "num_threads",
  "powerfmt",
  "serde",
  "time-core",
@@ -903,15 +725,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
+checksum = "765c97a5b985b7c11d7bc27fa927dc4fe6af3a6dfb021d28deb60d3bf51e76ef"
 
 [[package]]
 name = "time-macros"
-version = "0.2.19"
+version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2834e6017e3e5e4b9834939793b282bc03b37a3336245fa820e35e233e2a85de"
+checksum = "e8093bc3e81c3bc5f7879de09619d06c9a5a5e45ca44dfeeb7225bae38005c5c"
 dependencies = [
  "num-conv",
  "time-core",
@@ -936,7 +758,7 @@ checksum = "395ae124c09f9e6918a2310af6038fba074bcf474ac352496d5910dd59a2226d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn",
 ]
 
 [[package]]
@@ -991,21 +813,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.16"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a210d160f08b701c8721ba1c726c11662f877ea6b7094007e1ca9a1041945034"
-
-[[package]]
-name = "unicode-segmentation"
-version = "1.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
-
-[[package]]
-name = "unicode-width"
-version = "0.1.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
+checksum = "00e2473a93778eb0bad35909dff6a10d28e63f792f16ed15e404fca9d5eeedbe"
 
 [[package]]
 name = "utf8parse"
@@ -1018,24 +828,6 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
-
-[[package]]
-name = "vec_map"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
-
-[[package]]
-name = "version_check"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
-
-[[package]]
-name = "wasi"
-version = "0.11.0+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasi"
@@ -1147,7 +939,7 @@ version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3268f3d866458b787f390cf61f4bbb563b922d091359f9608842999eaee3943c"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags",
 ]
 
 [[package]]
@@ -1157,7 +949,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
 dependencies = [
  "byteorder",
- "zerocopy-derive",
+ "zerocopy-derive 0.7.35",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dde3bb8c68a8f3f1ed4ac9221aad6b10cece3e60a8e2ea54a6a2dec806d0084c"
+dependencies = [
+ "zerocopy-derive 0.8.20",
 ]
 
 [[package]]
@@ -1168,5 +969,16 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eea57037071898bf96a6da35fd626f4f27e9cee3ead2a6c703cf09d472b2e700"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,36 +1,10 @@
-[package]
-name = "armerge"
-version = "2.2.0"
-authors = ["tux3 <barrdetwix@gmail.com>"]
-edition = "2021"
-rust-version = "1.74"
-license = "MIT OR Apache-2.0"
-readme = "README.md"
-repository = "https://github.com/tux3/armerge/"
-categories = ["command-line-utilities", "development-tools::build-utils"]
-description = "Tool to merge and control visibility of static libraries"
+[workspace]
+resolver = "2"
+members = [
+    "armerge",
+    "armerge-cli",
+]
 
-[dependencies]
-objpoke = "0.3"
-clap = { version = "4.5.30", features = ["derive"] }
-ar = "0.9"
-tempfile = "3.3.0"
-rand = "0.8"
-object = "0.36.5"
-goblin = "0.9.2"
-regex = "1.3.9"
-rayon = "1.4.0"
-thiserror = "2.0.8"
-tracing = "0.1.35"
-tracing-subscriber = { version = "0.3.14", features = ["env-filter", "local-time"], optional = true }
-time = { version = "0.3.11", optional = true }
-
-[[bin]]
-name = "armerge"
-required-features = ["log_subscriber"]
-
-[features]
-default = ["log_subscriber"]
-# EXPERIMENTAL. Uses objpoke instead of objcopy for localizing ELF symbols in-place. Very fast, but not stable for production use.
-objpoke_symbols = []
-log_subscriber = ["dep:tracing-subscriber", "dep:time"]
+[workspace.dependencies]
+tracing = "0.1.41"
+regex = "1.11.1"

--- a/armerge-cli/Cargo.toml
+++ b/armerge-cli/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "armerge-cli"
+version = "2.2.0"
+authors = ["tux3 <barrdetwix@gmail.com>"]
+edition = "2021"
+rust-version = "1.74"
+license = "MIT OR Apache-2.0"
+readme = "../README.md"
+repository = "https://github.com/tux3/armerge/"
+categories = ["command-line-utilities", "development-tools::build-utils"]
+description = "Tool to merge and control visibility of static libraries"
+
+[[bin]]
+name = "armerge"
+path = "src/main.rs"
+
+[dependencies]
+armerge = { path = "../armerge" }
+
+tracing = { workspace = true }
+regex = { workspace = true }
+
+clap = { version = "4.5.31", features = ["derive"] }
+tracing-subscriber = { version = "0.3.19", features = ["env-filter", "time"] }
+time = { version = "0.3.39", features = ["formatting"] }

--- a/armerge/Cargo.toml
+++ b/armerge/Cargo.toml
@@ -1,0 +1,29 @@
+[package]
+name = "armerge"
+version = "2.2.0"
+authors = ["tux3 <barrdetwix@gmail.com>"]
+edition = "2021"
+rust-version = "1.74"
+license = "MIT OR Apache-2.0"
+readme = "../README.md"
+repository = "https://github.com/tux3/armerge/"
+categories = ["command-line-utilities", "development-tools::build-utils"]
+description = "Tool to merge and control visibility of static libraries"
+
+[dependencies]
+objpoke = { git = "https://github.com/dice-group/objpoke", rev = "c43ab668dafcb4bfbd7c16a0dd654ee759d7fbb3" }
+
+tracing = { workspace = true }
+regex = { workspace = true }
+
+ar = "0.9"
+tempfile = "3.18.0"
+rand = "0.9"
+object = "0.36.5"
+goblin = "0.9.2"
+rayon = "1.10.0"
+thiserror = "2.0.12"
+
+[features]
+# EXPERIMENTAL. Uses objpoke instead of objcopy for localizing ELF symbols in-place. Very fast, but not stable for production use.
+objpoke_symbols = []

--- a/armerge/src/arbuilder.rs
+++ b/armerge/src/arbuilder.rs
@@ -1,6 +1,5 @@
 use crate::MergeError;
-use std::fmt::Debug;
-use std::path::Path;
+use std::{fmt::Debug, path::Path};
 
 pub mod common;
 pub mod mac;

--- a/armerge/src/arbuilder/common.rs
+++ b/armerge/src/arbuilder/common.rs
@@ -1,9 +1,10 @@
-use crate::arbuilder::ArBuilder;
-use crate::{archives, MergeError};
+use crate::{arbuilder::ArBuilder, archives, MergeError};
 use ar::Builder;
-use std::fmt::{Debug, Formatter};
-use std::fs::File;
-use std::path::{Path, PathBuf};
+use std::{
+    fmt::{Debug, Formatter},
+    fs::File,
+    path::{Path, PathBuf},
+};
 
 pub struct CommonArBuilder {
     builder: Builder<File>,
@@ -22,9 +23,7 @@ impl Debug for CommonArBuilder {
 
 impl ArBuilder for CommonArBuilder {
     fn append_obj(&mut self, path: &Path) -> Result<(), MergeError> {
-        self.builder
-            .append_path(path)
-            .map_err(MergeError::WritingArchive)?;
+        self.builder.append_path(path).map_err(MergeError::WritingArchive)?;
         Ok(())
     }
 

--- a/armerge/src/arbuilder/mac.rs
+++ b/armerge/src/arbuilder/mac.rs
@@ -1,9 +1,9 @@
-use crate::arbuilder::ArBuilder;
-use crate::MergeError;
-use crate::MergeError::ExternalToolLaunchError;
-use std::ffi::OsString;
-use std::path::{Path, PathBuf};
-use std::process::Command;
+use crate::{arbuilder::ArBuilder, MergeError, MergeError::ExternalToolLaunchError};
+use std::{
+    ffi::OsString,
+    path::{Path, PathBuf},
+    process::Command,
+};
 use tracing::info;
 
 #[derive(Debug)]
@@ -26,11 +26,7 @@ impl ArBuilder for MacArBuilder {
 
 impl MacArBuilder {
     pub fn new(path: &Path) -> Self {
-        Self {
-            output_path: path.to_owned(),
-            obj_paths: vec![],
-            closed: false,
-        }
+        Self { output_path: path.to_owned(), obj_paths: vec![], closed: false }
     }
 
     fn write_obj(&mut self) -> Result<(), MergeError> {
@@ -56,20 +52,13 @@ impl MacArBuilder {
         info!(
             "Merging {} objects: libtool {}",
             count,
-            args.iter()
-                .map(|s| s.to_string_lossy())
-                .collect::<Vec<_>>()
-                .join(" ")
+            args.iter().map(|s| s.to_string_lossy()).collect::<Vec<_>>().join(" ")
         );
 
-        let output =
-            Command::new("libtool")
-                .args(&args)
-                .output()
-                .map_err(|e| ExternalToolLaunchError {
-                    tool: "libtool".to_string(),
-                    inner: e,
-                })?;
+        let output = Command::new("libtool")
+            .args(&args)
+            .output()
+            .map_err(|e| ExternalToolLaunchError { tool: "libtool".to_string(), inner: e })?;
         if output.status.success() {
             Ok(())
         } else {

--- a/armerge/src/input_library.rs
+++ b/armerge/src/input_library.rs
@@ -11,10 +11,7 @@ impl<R: Read> InputLibrary<R> {
     /// The library's name is used to get more meaningful messages in case of errors.
     /// The reader reads the binary data of the static library file.
     pub fn new<IntoString: Into<String>>(name: IntoString, reader: R) -> Self {
-        Self {
-            name: name.into(),
-            reader,
-        }
+        Self { name: name.into(), reader }
     }
 }
 

--- a/armerge/src/lib.rs
+++ b/armerge/src/lib.rs
@@ -5,18 +5,16 @@ mod merge_error;
 mod objects;
 mod process_input_error;
 
-use crate::arbuilder::common::CommonArBuilder;
-use crate::arbuilder::mac::MacArBuilder;
-use crate::arbuilder::ArBuilder;
-use crate::archives::{ArchiveContents, ExtractedArchive};
 pub use crate::input_library::InputLibrary;
-use crate::merge_error::MergeError;
-use crate::process_input_error::ProcessInputError;
+use crate::{
+    arbuilder::{common::CommonArBuilder, mac::MacArBuilder, ArBuilder},
+    archives::{ArchiveContents, ExtractedArchive},
+    merge_error::MergeError,
+    process_input_error::ProcessInputError,
+};
 use rayon::prelude::*;
 use regex::Regex;
-use std::fs::File;
-use std::io::Read;
-use std::path::Path;
+use std::{fs::File, io::Read, path::Path};
 use tracing::error;
 
 #[derive(Debug)]
@@ -58,10 +56,7 @@ impl ArMerger {
                     .replace('/', "_");
                 match File::open(path) {
                     Ok(f) => Ok(InputLibrary::new(filename, f)),
-                    Err(e) => Err(ProcessInputError::FileOpen {
-                        path: path.to_owned(),
-                        inner: e,
-                    }),
+                    Err(e) => Err(ProcessInputError::FileOpen { path: path.to_owned(), inner: e }),
                 }
             })
             .collect();
@@ -77,13 +72,17 @@ impl ArMerger {
             ArchiveContents::Elf => Box::new(CommonArBuilder::new(output.as_ref())),
             ArchiveContents::MachO => Box::new(MacArBuilder::new(output.as_ref())),
             ArchiveContents::Other => {
-                error!("Input archives contain neither ELF nor Mach-O files, trying to continue with your host toolchain");
+                error!(
+                    "Input archives contain neither ELF nor Mach-O files, trying to continue with your host toolchain"
+                );
                 arbuilder::host_platform_builder(output.as_ref())
-            }
+            },
             ArchiveContents::Mixed => {
-                error!("Input archives contain different object file formats, trying to continue with your host toolchain");
+                error!(
+                    "Input archives contain different object file formats, trying to continue with your host toolchain"
+                );
                 arbuilder::host_platform_builder(output.as_ref())
-            }
+            },
         })
     }
 
@@ -114,7 +113,7 @@ impl ArMerger {
         self,
         keep_or_remove: ArmergeKeepOrRemove,
         symbols_regexes: Iter,
-        object_order: impl IntoIterator<Item = String>
+        object_order: impl IntoIterator<Item = String>,
     ) -> Result<(), MergeError> {
         objects::merge(
             self.builder,
@@ -122,7 +121,7 @@ impl ArMerger {
             self.extracted.object_dir,
             keep_or_remove,
             symbols_regexes.into_iter().collect(),
-            object_order.into_iter().enumerate().map(|(i, s)| (s, i)).collect()
+            object_order.into_iter().enumerate().map(|(i, s)| (s, i)).collect(),
         )
     }
 }

--- a/armerge/src/merge_error.rs
+++ b/armerge/src/merge_error.rs
@@ -1,14 +1,10 @@
-use std::ffi::OsString;
-use std::io;
-use std::path::PathBuf;
+use std::{ffi::OsString, io, path::PathBuf};
 use thiserror::Error;
 
 /// Errors that happen while creating the merged output static library from the extracted inputs
 #[derive(Debug, Error)]
 pub enum MergeError {
-    #[error(
-        "{reason}: {tool:?} {args:?})\nstdout: {stdout}\nstderr: {stderr}"
-    )]
+    #[error("{reason}: {tool:?} {args:?})\nstdout: {stdout}\nstderr: {stderr}")]
     ExternalToolError {
         reason: String,
         tool: String,

--- a/armerge/src/objects.rs
+++ b/armerge/src/objects.rs
@@ -6,12 +6,14 @@ mod syms;
 mod builtin_filter;
 mod system_filter;
 
-use crate::arbuilder::ArBuilder;
-use crate::archives::get_object_name_from_path;
-use crate::{ArchiveContents, ArmergeKeepOrRemove, MergeError};
+use crate::{
+    arbuilder::ArBuilder, archives::get_object_name_from_path, ArchiveContents, ArmergeKeepOrRemove, MergeError,
+};
 use regex::Regex;
-use std::collections::HashMap;
-use std::path::{Path, PathBuf};
+use std::{
+    collections::HashMap,
+    path::{Path, PathBuf},
+};
 use tempfile::TempDir;
 
 pub struct ObjectTempDir {
@@ -30,23 +32,11 @@ pub fn merge_required_objects(
     #[allow(clippy::if_same_then_else)] // Clippy can't see both [cfg] at once
     if contents_type == ArchiveContents::Elf {
         #[cfg(feature = "objpoke_symbols")]
-        builtin_filter::merge_required_objects(
-            obj_dir,
-            merged_path,
-            objs,
-            keep_or_remove,
-            regexes,
-        )?;
+        builtin_filter::merge_required_objects(obj_dir, merged_path, objs, keep_or_remove, regexes)?;
         #[cfg(not(feature = "objpoke_symbols"))]
         system_filter::merge_required_objects(obj_dir, merged_path, objs, keep_or_remove, regexes)?;
     } else if contents_type == ArchiveContents::MachO {
-        system_filter::merge_required_macho_objects(
-            obj_dir,
-            merged_path,
-            objs,
-            keep_or_remove,
-            regexes,
-        )?;
+        system_filter::merge_required_macho_objects(obj_dir, merged_path, objs, keep_or_remove, regexes)?;
     } else {
         system_filter::merge_required_objects(obj_dir, merged_path, objs, keep_or_remove, regexes)?;
     }
@@ -71,8 +61,7 @@ pub fn merge(
         regexes.push(Regex::new("^_?_Unwind_.*").expect("Failed to compile Regex"));
     }
 
-    let required_objects =
-        filter_deps::filter_required_objects(&objects.objects, keep_or_remove, &regexes)?;
+    let required_objects = filter_deps::filter_required_objects(&objects.objects, keep_or_remove, &regexes)?;
 
     if required_objects.is_empty() {
         return Err(MergeError::NoObjectsLeft);

--- a/armerge/src/objects/filter_deps.rs
+++ b/armerge/src/objects/filter_deps.rs
@@ -1,19 +1,16 @@
-use std::collections::{BTreeMap, HashSet};
-use std::path::PathBuf;
+use std::{
+    collections::{BTreeMap, HashSet},
+    path::PathBuf,
+};
 
 use crate::{ArmergeKeepOrRemove, MergeError};
 use rayon::prelude::*;
 use regex::Regex;
 use tracing::{event_enabled, info, Level};
 
-use crate::archives::get_object_name_from_path;
-use crate::objects::syms::ObjectSyms;
+use crate::{archives::get_object_name_from_path, objects::syms::ObjectSyms};
 
-fn add_deps_recursive(
-    objs_set: &mut HashSet<PathBuf>,
-    syms: &BTreeMap<PathBuf, ObjectSyms>,
-    obj: &ObjectSyms,
-) {
+fn add_deps_recursive(objs_set: &mut HashSet<PathBuf>, syms: &BTreeMap<PathBuf, ObjectSyms>, obj: &ObjectSyms) {
     for dep in &obj.deps {
         if objs_set.insert(dep.to_owned()) {
             add_deps_recursive(objs_set, syms, syms.get(dep).unwrap());
@@ -28,12 +25,7 @@ pub fn filter_required_objects(
 ) -> Result<BTreeMap<PathBuf, ObjectSyms>, MergeError> {
     let mut object_syms = objects
         .into_par_iter()
-        .map(|obj_path| {
-            Ok::<_, MergeError>((
-                obj_path.to_owned(),
-                ObjectSyms::new(obj_path, keep_or_remove, regexes)?,
-            ))
-        })
+        .map(|obj_path| Ok::<_, MergeError>((obj_path.to_owned(), ObjectSyms::new(obj_path, keep_or_remove, regexes)?)))
         .collect::<Result<BTreeMap<PathBuf, ObjectSyms>, _>>()?;
     ObjectSyms::check_dependencies(&mut object_syms);
 

--- a/armerge/src/objects/merge.rs
+++ b/armerge/src/objects/merge.rs
@@ -1,8 +1,10 @@
 use crate::MergeError;
-use std::ffi::{OsStr, OsString};
-use std::path::Path;
-use std::process::Command;
-use std::str::FromStr;
+use std::{
+    ffi::{OsStr, OsString},
+    path::Path,
+    process::Command,
+    str::FromStr,
+};
 use tracing::{debug, info};
 
 pub fn create_merged_object(
@@ -39,11 +41,7 @@ pub fn create_merged_object(
             .map(|p| p.as_ref().as_os_str().into()),
     );
 
-    let trace_args = args
-        .iter()
-        .map(|s| s.to_string_lossy())
-        .collect::<Vec<_>>()
-        .join(" ");
+    let trace_args = args.iter().map(|s| s.to_string_lossy()).collect::<Vec<_>>().join(" ");
     if silent {
         debug!(
             "Merging {} objects: {} {}",
@@ -60,12 +58,10 @@ pub fn create_merged_object(
         );
     }
 
-    let output = Command::new(&ld_path).args(&args).output().map_err(|e| {
-        MergeError::ExternalToolLaunchError {
-            tool: ld_path.to_string_lossy().to_string(),
-            inner: e,
-        }
-    })?;
+    let output = Command::new(&ld_path)
+        .args(&args)
+        .output()
+        .map_err(|e| MergeError::ExternalToolLaunchError { tool: ld_path.to_string_lossy().to_string(), inner: e })?;
     if output.status.success() {
         Ok(())
     } else {

--- a/armerge/src/objects/syms.rs
+++ b/armerge/src/objects/syms.rs
@@ -2,8 +2,10 @@ use crate::{ArmergeKeepOrRemove, MergeError};
 use object::{Object, ObjectSymbol, SymbolKind};
 use rayon::prelude::*;
 use regex::Regex;
-use std::collections::{BTreeMap, HashSet};
-use std::path::{Path, PathBuf};
+use std::{
+    collections::{BTreeMap, HashSet},
+    path::{Path, PathBuf},
+};
 
 pub struct ObjectSyms {
     globals: HashSet<String>,
@@ -13,25 +15,16 @@ pub struct ObjectSyms {
 }
 
 impl ObjectSyms {
-    pub fn new(
-        object_path: &Path,
-        keep_or_remove: ArmergeKeepOrRemove,
-        regexes: &[Regex],
-    ) -> Result<Self, MergeError> {
+    pub fn new(object_path: &Path, keep_or_remove: ArmergeKeepOrRemove, regexes: &[Regex]) -> Result<Self, MergeError> {
         let mut globals = HashSet::new();
         let mut undefineds = HashSet::new();
         let mut has_exported_symbols = false;
 
         let data = std::fs::read(object_path)?;
-        let file = object::File::parse(data.as_slice()).map_err(|e| MergeError::InvalidObject {
-            path: object_path.to_owned(),
-            inner: e,
-        })?;
+        let file = object::File::parse(data.as_slice())
+            .map_err(|e| MergeError::InvalidObject { path: object_path.to_owned(), inner: e })?;
         for sym in file.symbols() {
-            if sym.kind() != SymbolKind::Text
-                && sym.kind() != SymbolKind::Data
-                && sym.kind() != SymbolKind::Unknown
-            {
+            if sym.kind() != SymbolKind::Text && sym.kind() != SymbolKind::Data && sym.kind() != SymbolKind::Unknown {
                 continue;
             }
 
@@ -62,12 +55,7 @@ impl ObjectSyms {
             }
         }
 
-        Ok(Self {
-            globals,
-            undefineds,
-            has_exported_symbols,
-            deps: Default::default(),
-        })
+        Ok(Self { globals, undefineds, has_exported_symbols, deps: Default::default() })
     }
 
     pub fn has_dependency(&self, obj_syms: &ObjectSyms) -> bool {

--- a/armerge/src/objects/system_filter.rs
+++ b/armerge/src/objects/system_filter.rs
@@ -1,13 +1,14 @@
 use goblin::{peek_bytes, Hint};
-use std::collections::HashSet;
-use std::ffi::OsString;
-use std::io::{Read, Seek, SeekFrom, Write};
-use std::path::{Path, PathBuf};
-use std::process::Command;
-use std::str::FromStr;
+use std::{
+    collections::HashSet,
+    ffi::OsString,
+    io::{Read, Seek, SeekFrom, Write},
+    path::{Path, PathBuf},
+    process::Command,
+    str::FromStr,
+};
 
-use crate::objects::merge::create_merged_object;
-use crate::{ArmergeKeepOrRemove, MergeError};
+use crate::{objects::merge::create_merged_object, ArmergeKeepOrRemove, MergeError};
 use object::{Object, ObjectSymbol, SymbolKind};
 use regex::Regex;
 use std::fs::File;
@@ -50,10 +51,8 @@ pub fn create_symbol_filter_list(
     for object_path in objects.into_iter() {
         let object_path = object_path.as_ref();
         let data = std::fs::read(object_path)?;
-        let file = object::File::parse(data.as_slice()).map_err(|e| MergeError::InvalidObject {
-            path: object_path.to_owned(),
-            inner: e,
-        })?;
+        let file = object::File::parse(data.as_slice())
+            .map_err(|e| MergeError::InvalidObject { path: object_path.to_owned(), inner: e })?;
         'next_symbol: for sym in file.symbols() {
             if keep_or_remove == ArmergeKeepOrRemove::KeepSymbols
                 && (!sym.is_global()
@@ -114,10 +113,7 @@ fn filter_symbols(object_path: &Path, filter_list_path: &Path) -> Result<(), Mer
     info!(
         "{} {}",
         objcopy_path.to_string_lossy(),
-        args.iter()
-            .map(|s| s.to_string_lossy())
-            .collect::<Vec<_>>()
-            .join(" ")
+        args.iter().map(|s| s.to_string_lossy()).collect::<Vec<_>>().join(" ")
     );
 
     let output = Command::new(&objcopy_path)
@@ -185,7 +181,7 @@ fn demote_elf_comdats(merged_path: &Path, keep_regexes: &[Regex]) -> Result<(), 
                 file.read_to_end(&mut data)?;
                 objpoke::elf::demote_comdat_groups(data, keep_regexes)
                     .map_err(|e| MergeError::InternalError(e.into()))?
-            }
+            },
             // We don't know about needing to demote any COMDATs in PE/Mach-O files
             Ok(Hint::Mach(_) | Hint::MachFat(_)) => return Ok(()),
             Ok(Hint::PE) => return Ok(()),

--- a/armerge/src/process_input_error.rs
+++ b/armerge/src/process_input_error.rs
@@ -1,5 +1,4 @@
-use std::io;
-use std::path::PathBuf;
+use std::{io, path::PathBuf};
 use thiserror::Error;
 
 /// Errors that happen while processing inputs static libraries and extracting objects from them


### PR DESCRIPTION
Same as for `objpoke`, I've seperated the library from the CLI to avoid unecessary dependencies.